### PR TITLE
Fix printing order

### DIFF
--- a/pptree/pptree.py
+++ b/pptree/pptree.py
@@ -33,7 +33,7 @@ def print_tree(current_node, childattr='children', nameattr='name', horizontal=T
         a = sorted(children(current_node), key=lambda node: nb_children(node))
         b = []
         while a and sum(size_branch[node] for node in b) < sum(size_branch[node] for node in a):
-            b.append(a.pop())
+            b.insert(0, a.pop())
 
         return a, b
 

--- a/pptree/pptree.py
+++ b/pptree/pptree.py
@@ -30,7 +30,7 @@ def print_tree(current_node, childattr='children', nameattr='name', horizontal=T
         size_branch = {child: nb_children(child) for child in children(current_node)}
 
         """ Creation of balanced lists for "a" branch and "b" branch. """
-        a = sorted(children(current_node), key=lambda node: nb_children(node))
+        a = children(current_node)
         b = []
         while a and sum(size_branch[node] for node in b) < sum(size_branch[node] for node in a):
             b.insert(0, a.pop())


### PR DESCRIPTION
Fixes issues #2 and #8 

Balanced list of b branch is mixed,
because b.append(..) is used.
b.insert(0, ..) should be used instead.

This code:
```
from pptree import *

shame = Node("shame")

conscience = Node("conscience", shame)
selfdisgust = Node("selfdisgust", shame)
embarrassment = Node("embarrassment", shame)

selfconsciousness = Node("selfconsciousness", embarrassment)
shamefacedness = Node("shamefacedness", embarrassment)
chagrin = Node("chagrin", embarrassment)
discomfiture = Node("discomfiture", embarrassment)
abashment = Node("abashment", embarrassment)
confusion = Node("confusion", embarrassment)
  
print_tree(shame, horizontal=False)
```

Currently prints:
```
 shame                                                                                     
conscience   selfdisgust                                             embarrassment                               
                              selfconsciousness   shamefacedness   chagrin   confusion   abashment   discomfiture
```

But it should do:
```
 shame                                                                                     
conscience   selfdisgust                                             embarrassment                               
                              selfconsciousness   shamefacedness   chagrin   discomfiture   abashment   confusion
```